### PR TITLE
Fix Unknown lvalue 'PIDFILE' in section 'Service', ignoring

### DIFF
--- a/openplotterKplex/kplexPostInstall.py
+++ b/openplotterKplex/kplexPostInstall.py
@@ -35,7 +35,7 @@ def main():
 		'After=syslog.target network.target audit.service\n'+
 		'[Service]\n'+
 		'Type=forking\n'+
-		'PIDFILE=/var/run/kplex.pid\n'+
+		'PIDFile=/var/run/kplex.pid\n'+
 		'ExecStart=/usr/bin/kplex -p /var/run/kplex.pid -o mode=background\n'+
 		'KillMode=process\n'+
 		'[Install]\n'+


### PR DESCRIPTION
pi@openplotter:~ $ systemctl status openplotter-kplex
● openplotter-kplex.service - NMEA 0183 Multiplexer
   Loaded: loaded (/etc/systemd/system/openplotter-kplex.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Fri 2020-05-08 15:42:42 CEST; 1 day 22h ago
     Docs: http://www.stripydog.com/kplex/configuration.html

May 10 13:50:39 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:50:40 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:50:41 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:50:41 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:50:43 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:50:43 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:50:44 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:51:03 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:51:06 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: Unknown lvalue 'PIDFILE' in section 'Service', ignoring
May 10 13:59:24 openplotter systemd[1]: /etc/systemd/system/openplotter-kplex.service:7: PIDFile= references path below legacy directory /var/run/, updating /var/run/kplex.pid → /run/kplex.pid; p